### PR TITLE
feat: add Open Graph, Twitter Cards and JSON-LD

### DIFF
--- a/.github/workflows/weekly-post.yml
+++ b/.github/workflows/weekly-post.yml
@@ -1,0 +1,37 @@
+name: Weekly auto-publish
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Lunes 8:00 UTC
+  workflow_dispatch: # Permite ejecución manual
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate article
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: node scripts/generate-post.js
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add articulos/ posts.json
+          git commit -m "feat: auto-publish weekly article $(date +%Y-%m-%d)"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/PLAN-AUTOPUBLICACION.md
+++ b/PLAN-AUTOPUBLICACION.md
@@ -65,6 +65,23 @@ Cron (lunes 8am) → generate-post.js → OpenAI API (GPT + DALL·E)
 - Git push nativo (no necesita tokens extra)
 - Un solo YAML, sin deploy de nada
 
+## Analytics y observabilidad
+
+### Microsoft Clarity
+
+Herramienta gratuita de analytics de comportamiento (heatmaps, grabaciones de sesión, métricas).
+
+1. Crear proyecto en [clarity.microsoft.com](https://clarity.microsoft.com)
+2. Copiar el snippet de tracking
+3. Pegarlo en `articulos/plantilla`, `index.html` y `posts.html` (dentro de `<head>`)
+4. Los artículos futuros lo heredan automáticamente vía la plantilla
+
+**Qué aporta:**
+- Heatmaps de clics y scroll
+- Grabaciones de sesiones reales
+- Métricas de engagement (dead clicks, rage clicks, quick backs)
+- Dashboard sin costo ni límite de tráfico
+
 ## Pendientes opcionales
 
 - [ ] Rotación de temas para variedad en el prompt

--- a/articulos/delapencaaljarro/de-la-penca-al-jarro.html
+++ b/articulos/delapencaaljarro/de-la-penca-al-jarro.html
@@ -5,6 +5,46 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>De la penca al jarro — Guardianes del Pulque</title>
   <meta name="description" content="Del maguey al vaso: así viaja el pulque vivo desde el campo, el tinacal y la pulquería hasta tu casa." />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="De la penca al jarro" />
+  <meta property="og:description" content="Del maguey al vaso: así viaja el pulque vivo desde el campo, el tinacal y la pulquería hasta tu casa." />
+  <meta property="og:image" content="https://guardianesdelpulque.com/articulos/delapencaaljarro/de_la_penca_al_jarro.png" />
+  <meta property="og:url" content="https://guardianesdelpulque.com/articulos/delapencaaljarro/de-la-penca-al-jarro.html" />
+  <meta property="og:site_name" content="Guardianes del Pulque" />
+  <meta property="og:locale" content="es_MX" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="De la penca al jarro" />
+  <meta name="twitter:description" content="Del maguey al vaso: así viaja el pulque vivo desde el campo, el tinacal y la pulquería hasta tu casa." />
+  <meta name="twitter:image" content="https://guardianesdelpulque.com/articulos/delapencaaljarro/de_la_penca_al_jarro.png" />
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "De la penca al jarro",
+    "description": "Del maguey al vaso: así viaja el pulque vivo desde el campo, el tinacal y la pulquería hasta tu casa.",
+    "image": "https://guardianesdelpulque.com/articulos/delapencaaljarro/de_la_penca_al_jarro.png",
+    "author": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "url": "https://guardianesdelpulque.com"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://guardianesdelpulque.com/images/logo_transparente.png"
+      }
+    }
+  }
+  </script>
+
   <style>
     *,*::before,*::after{box-sizing:border-box}
     body{

--- a/articulos/guiadeadobe/guiadeadobe.html
+++ b/articulos/guiadeadobe/guiadeadobe.html
@@ -5,6 +5,46 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Guía práctica de adobe — Guardianes del Pulque</title>
   <meta name="description" content="Guía clara para mezclar, moldear y curar adobe con enfoque comunitario y de territorio." />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Guía práctica de adobe" />
+  <meta property="og:description" content="Guía clara para mezclar, moldear y curar adobe con enfoque comunitario y de territorio." />
+  <meta property="og:image" content="https://guardianesdelpulque.com/articulos/guiadeadobe/guiadeadobe.png" />
+  <meta property="og:url" content="https://guardianesdelpulque.com/articulos/guiadeadobe/guiadeadobe.html" />
+  <meta property="og:site_name" content="Guardianes del Pulque" />
+  <meta property="og:locale" content="es_MX" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Guía práctica de adobe" />
+  <meta name="twitter:description" content="Guía clara para mezclar, moldear y curar adobe con enfoque comunitario y de territorio." />
+  <meta name="twitter:image" content="https://guardianesdelpulque.com/articulos/guiadeadobe/guiadeadobe.png" />
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Guía práctica de adobe",
+    "description": "Guía clara para mezclar, moldear y curar adobe con enfoque comunitario y de territorio.",
+    "image": "https://guardianesdelpulque.com/articulos/guiadeadobe/guiadeadobe.png",
+    "author": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "url": "https://guardianesdelpulque.com"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://guardianesdelpulque.com/images/logo_transparente.png"
+      }
+    }
+  }
+  </script>
+
   <style>
     *,*::before,*::after{box-sizing:border-box}
     body{

--- a/articulos/microbiotadelpulque/microbiotadelpulque.html
+++ b/articulos/microbiotadelpulque/microbiotadelpulque.html
@@ -5,6 +5,46 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Microbiota del pulque: quién es quién — Guardianes del Pulque</title>
   <meta name="description" content="Levaduras y bacterias lácticas que dan cuerpo, aroma y textura al pulque vivo." />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Microbiota del pulque: quién es quién" />
+  <meta property="og:description" content="Levaduras y bacterias lácticas que dan cuerpo, aroma y textura al pulque vivo." />
+  <meta property="og:image" content="https://guardianesdelpulque.com/articulos/microbiotadelpulque/microbiotadelpulque.png" />
+  <meta property="og:url" content="https://guardianesdelpulque.com/articulos/microbiotadelpulque/microbiotadelpulque.html" />
+  <meta property="og:site_name" content="Guardianes del Pulque" />
+  <meta property="og:locale" content="es_MX" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Microbiota del pulque: quién es quién" />
+  <meta name="twitter:description" content="Levaduras y bacterias lácticas que dan cuerpo, aroma y textura al pulque vivo." />
+  <meta name="twitter:image" content="https://guardianesdelpulque.com/articulos/microbiotadelpulque/microbiotadelpulque.png" />
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Microbiota del pulque: quién es quién",
+    "description": "Levaduras y bacterias lácticas que dan cuerpo, aroma y textura al pulque vivo.",
+    "image": "https://guardianesdelpulque.com/articulos/microbiotadelpulque/microbiotadelpulque.png",
+    "author": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "url": "https://guardianesdelpulque.com"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://guardianesdelpulque.com/images/logo_transparente.png"
+      }
+    }
+  }
+  </script>
+
   <style>
     *,*::before,*::after{box-sizing:border-box}
     body{

--- a/index.html
+++ b/index.html
@@ -5,6 +5,34 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Guardianes del Pulque</title>
   <meta name="description" content="Pulque, tierra y maguey: artículos, guías y proyectos con diseño moderno y animado." />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Guardianes del Pulque" />
+  <meta property="og:description" content="Pulque, tierra y maguey: artículos, guías y proyectos." />
+  <meta property="og:image" content="https://guardianesdelpulque.com/images/logo_transparente.png" />
+  <meta property="og:url" content="https://guardianesdelpulque.com/" />
+  <meta property="og:site_name" content="Guardianes del Pulque" />
+  <meta property="og:locale" content="es_MX" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Guardianes del Pulque" />
+  <meta name="twitter:description" content="Pulque, tierra y maguey: artículos, guías y proyectos." />
+  <meta name="twitter:image" content="https://guardianesdelpulque.com/images/logo_transparente.png" />
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Guardianes del Pulque",
+    "url": "https://guardianesdelpulque.com",
+    "logo": "https://guardianesdelpulque.com/images/logo_transparente.png",
+    "description": "Pulque, tierra y maguey: artículos, guías y proyectos con diseño moderno y animado."
+  }
+  </script>
+
   <style>
     *,*::before,*::after{box-sizing:border-box}
     body{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "guardianesdelpulque",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "openai": "^6.27.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.27.0.tgz",
+      "integrity": "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "openai": "^6.27.0"
+  }
+}

--- a/scripts/generate-post.js
+++ b/scripts/generate-post.js
@@ -3,6 +3,7 @@ const path = require("path");
 const OpenAI = require("openai");
 
 const openai = new OpenAI();
+const SITE_URL = "https://guardianesdelpulque.com";
 
 // ── Temas ──────────────────────────────────────────────────────────────────
 const TOPICS = [
@@ -115,14 +116,56 @@ function validateTag(tag) {
 }
 
 // ── Template HTML ──────────────────────────────────────────────────────────
-function buildHTML({ title, excerpt, body, tag, emoji, slug, dateStr }) {
+function buildHTML({ title, excerpt, body, tag, emoji, slug, dateStr, isoDate }) {
+  const safeExcerpt = excerpt.replace(/"/g, "&quot;");
   return `<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${title} — Guardianes del Pulque</title>
-  <meta name="description" content="${excerpt.replace(/"/g, "&quot;")}" />
+  <meta name="description" content="${safeExcerpt}" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="${safeExcerpt}" />
+  <meta property="og:image" content="${SITE_URL}/articulos/${slug}/${slug}.png" />
+  <meta property="og:url" content="${SITE_URL}/articulos/${slug}/${slug}.html" />
+  <meta property="og:site_name" content="Guardianes del Pulque" />
+  <meta property="og:locale" content="es_MX" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:description" content="${safeExcerpt}" />
+  <meta name="twitter:image" content="${SITE_URL}/articulos/${slug}/${slug}.png" />
+
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "${title}",
+    "description": "${safeExcerpt}",
+    "image": "${SITE_URL}/articulos/${slug}/${slug}.png",
+    "datePublished": "${isoDate}",
+    "author": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "url": "${SITE_URL}"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Guardianes del Pulque",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "${SITE_URL}/images/logo_transparente.png"
+      }
+    }
+  }
+  </script>
+
   <style>
     *,*::before,*::after{box-sizing:border-box}
     body{
@@ -532,6 +575,7 @@ async function generateArticle() {
     emoji,
     slug,
     dateStr,
+    isoDate: now.toISOString().split("T")[0],
   });
   fs.writeFileSync(path.join(artDir, `${slug}.html`), html);
 

--- a/scripts/generate-post.js
+++ b/scripts/generate-post.js
@@ -1,0 +1,562 @@
+const fs = require("fs");
+const path = require("path");
+const OpenAI = require("openai");
+
+const openai = new OpenAI();
+
+// ── Temas ──────────────────────────────────────────────────────────────────
+const TOPICS = [
+  "Pulque, aguamiel, fermentacion tradicional, maguey pulquero, tlachiquero",
+  "Bioconstruccion con tierra, adobe, bahareque, tierra compactada, techos verdes",
+  "Naturaleza, restauracion ecologica, polinizadores, humedales, suelos vivos",
+  "Maguey, usos del agave, fibras, ixtle, pencas",
+  "Milpa, agricultura tradicional, policultivo, maiz, frijol, calabaza",
+  "Agua, captacion pluvial, filtracion natural, humedales artificiales",
+  "Defensa del territorio, autonomia comunitaria, derechos indigenas, tierra y agua",
+];
+
+// ── Tags válidos ───────────────────────────────────────────────────────────
+const VALID_TAGS = ["Pulque", "Bioconstruccion", "Naturaleza", "Territorio"];
+const TAG_EMOJI = {
+  Pulque: "🍶",
+  Bioconstruccion: "🏗️",
+  Naturaleza: "🌿",
+  Territorio: "✊",
+};
+const DEFAULT_TAG = "Naturaleza";
+
+// ── Perfiles de tono ───────────────────────────────────────────────────────
+const TONE_PROFILES = [
+  {
+    name: "practico-calido",
+    systemPrompt:
+      "Eres un redactor experto en temas rurales, ecologicos y de territorio mexicano. " +
+      "Escribes articulos claros, calidos y practicos para comunidades. " +
+      "Tu tono es directo, comunitario y respetuoso.",
+    sectionRange: [5, 8],
+    temperatureRange: [0.7, 0.9],
+  },
+  {
+    name: "poetico-con-mesura",
+    systemPrompt:
+      "Eres un escritor que combina conocimiento rural y ecologico con un lenguaje lirico pero contenido. " +
+      "Usas metaforas del territorio mexicano sin caer en excesos. " +
+      "Tu prosa respira como la milpa: con ritmo y proposito.",
+    sectionRange: [5, 7],
+    temperatureRange: [0.85, 1.0],
+  },
+  {
+    name: "cortito-conciso",
+    systemPrompt:
+      "Eres un redactor que escribe fichas y guias rapidas sobre temas rurales y ecologicos de Mexico. " +
+      "Vas directo al grano. Frases cortas, listas claras, sin rodeos. " +
+      "Cada seccion es breve y util.",
+    sectionRange: [3, 4],
+    temperatureRange: [0.6, 0.8],
+  },
+  {
+    name: "narrativo",
+    systemPrompt:
+      "Eres un narrador que cuenta historias y escenas del campo mexicano para transmitir saberes. " +
+      "Empiezas con una escena vivida (un tlachiquero al amanecer, una cuadrilla mezclando adobe, " +
+      "una lluvia cayendo en la milpa) y de ahi extraes aprendizajes practicos. " +
+      "Equilibras relato y ensenanza.",
+    sectionRange: [5, 7],
+    temperatureRange: [0.85, 1.0],
+  },
+];
+
+// ── Utilidades ─────────────────────────────────────────────────────────────
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function fechaMx(date) {
+  const meses = [
+    "enero", "febrero", "marzo", "abril", "mayo", "junio",
+    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+  ];
+  return `${date.getDate()} de ${meses[date.getMonth()]} de ${date.getFullYear()}`;
+}
+
+function randInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randFloat(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function uniqueSlug(base) {
+  const articulosDir = path.join(__dirname, "..", "articulos");
+  let slug = base;
+  let n = 2;
+  while (fs.existsSync(path.join(articulosDir, slug))) {
+    slug = `${base}-${n}`;
+    n++;
+  }
+  return slug;
+}
+
+function validateTag(tag) {
+  if (VALID_TAGS.includes(tag)) return tag;
+  // Accept new tags GPT suggests — add emoji fallback
+  if (typeof tag === "string" && tag.length > 0 && tag.length < 40) return tag;
+  return DEFAULT_TAG;
+}
+
+// ── Template HTML ──────────────────────────────────────────────────────────
+function buildHTML({ title, excerpt, body, tag, emoji, slug, dateStr }) {
+  return `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title} — Guardianes del Pulque</title>
+  <meta name="description" content="${excerpt.replace(/"/g, "&quot;")}" />
+  <style>
+    *,*::before,*::after{box-sizing:border-box}
+    body{
+      margin:0;
+      font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,'Helvetica Neue',Arial,'Apple Color Emoji','Segoe UI Emoji';
+      line-height:1.6;
+      color:#0f172a;
+      background:#f6f8fb;
+    }
+    :root{
+      --brand:#059669;
+      --ink:#0f172a;
+      --muted:#6b7280;
+      --card:#ffffff;
+      --stroke:#e5e7eb;
+      --maxw:780px;
+    }
+    a{color:inherit;text-decoration:none}
+    img{max-width:100%;display:block}
+
+    .container{max-width:1180px;margin-inline:auto;padding:0 16px}
+    @media (min-width:640px){.container{padding:0 24px}}
+
+    /* NAV */
+    .nav{
+      position:sticky;top:0;z-index:40;
+      background:rgba(255,255,255,.9);
+      backdrop-filter:saturate(180%) blur(14px);
+      border-bottom:1px solid rgba(15,23,42,.06);
+    }
+    .nav .row{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      padding:8px 0;
+      gap:.75rem;
+    }
+    .brand{
+      display:flex;
+      align-items:center;
+      gap:.45rem;
+      font-weight:700;
+    }
+    .brand-logo{
+      height:34px;
+      width:auto;
+    }
+    .brand-text{
+      font-size:.98rem;
+      letter-spacing:.01em;
+    }
+    .links{
+      display:flex;
+      flex-wrap:wrap;
+      gap:.35rem;
+      justify-content:flex-end;
+      align-items:center;
+    }
+    .chip{
+      display:inline-flex;
+      align-items:center;
+      gap:.35rem;
+      padding:.4rem .8rem;
+      border-radius:999px;
+      border:1px solid var(--brand);
+      font-size:.72rem;
+      font-weight:600;
+      color:var(--brand);
+      background:#ffffff;
+      cursor:pointer;
+      transition:all .16s ease;
+      white-space:nowrap;
+    }
+    .chip .emoji{font-size:.9rem}
+    .chip:hover{
+      background:var(--brand);
+      color:#020817;
+      transform:translateY(-1px);
+      box-shadow:0 8px 18px rgba(15,23,42,.16);
+    }
+
+    /* HERO */
+    .hero-article{
+      padding:24px 0 8px;
+    }
+    .hero-inner{
+      max-width:var(--maxw);
+      margin:0 auto;
+    }
+    .eyebrow{
+      display:inline-flex;
+      align-items:center;
+      gap:.4rem;
+      padding:.25rem .7rem;
+      border-radius:999px;
+      background:rgba(5,150,105,.08);
+      color:#047857;
+      font-size:.7rem;
+      font-weight:600;
+      margin-bottom:.4rem;
+    }
+    .title{
+      margin:0;
+      font-size:clamp(26px,5.4vw,40px);
+      line-height:1.1;
+      letter-spacing:-.01em;
+    }
+    .subtitle{
+      margin:.4rem 0 0;
+      color:var(--muted);
+      font-size:.9rem;
+      max-width:46rem;
+    }
+    .meta{
+      margin-top:.6rem;
+      font-size:.72rem;
+      color:#9ca3af;
+      display:flex;
+      flex-wrap:wrap;
+      gap:.75rem;
+      align-items:center;
+    }
+
+    /* Cover */
+    .cover-wrap{
+      max-width:var(--maxw);
+      margin:16px auto 0;
+      border-radius:24px;
+      background:radial-gradient(circle at top,rgba(5,150,105,.12),transparent),
+                 #020817;
+      padding:14px;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+    }
+    .cover-img{
+      width:100%;
+      height:auto;
+      object-fit:cover;
+      border-radius:16px;
+    }
+
+    /* CONTENIDO */
+    .article{
+      max-width:var(--maxw);
+      margin:22px auto 40px;
+      background:var(--card);
+      border-radius:24px;
+      padding:18px 16px 20px;
+      box-shadow:0 18px 45px rgba(15,23,42,.12);
+      border:1px solid rgba(148,163,253,.1);
+    }
+    @media (min-width:700px){
+      .article{padding:26px 26px 24px;}
+    }
+    .article h2{
+      font-size:1.12rem;
+      margin:1.4rem 0 .4rem;
+    }
+    .article p{
+      margin:.45rem 0;
+      color:#374151;
+      font-size:.9rem;
+    }
+    .article ul,.article ol{
+      margin:.35rem 0 .6rem 1.2rem;
+      padding:0;
+      color:#374151;
+      font-size:.88rem;
+    }
+    .divider{
+      margin:1.3rem 0;
+      border-top:1px solid rgba(148,163,253,.22);
+    }
+
+    /* CTA */
+    .cta-section{
+      margin:1.5rem 0;
+      padding:1.2rem;
+      border-radius:16px;
+      background:rgba(5,150,105,.04);
+      border:1px dashed rgba(5,150,105,.25);
+      text-align:center;
+    }
+    .cta-section h2{
+      font-size:1rem;
+      margin:0 0 .5rem;
+      color:#065f46;
+    }
+    .cta-section p{
+      font-size:.82rem;
+      color:#374151;
+      margin:0 0 .8rem;
+    }
+    .cta-form{
+      display:flex;
+      gap:.5rem;
+      justify-content:center;
+      flex-wrap:wrap;
+      margin-bottom:.8rem;
+    }
+    .cta-form input[type="email"]{
+      padding:.45rem .75rem;
+      border:1px solid var(--stroke);
+      border-radius:999px;
+      font-size:.82rem;
+      width:220px;
+      max-width:100%;
+    }
+    .cta-form button{
+      padding:.45rem 1rem;
+      border:none;
+      border-radius:999px;
+      background:var(--brand);
+      color:#fff;
+      font-size:.82rem;
+      font-weight:600;
+      cursor:pointer;
+    }
+    .cta-form button:hover{
+      background:#047857;
+    }
+
+    /* Footer articulo */
+    .article-footer{
+      display:flex;
+      flex-wrap:wrap;
+      gap:.5rem;
+      justify-content:space-between;
+      align-items:center;
+      margin-top:1.1rem;
+      font-size:.78rem;
+      color:#6b7280;
+    }
+    .article-footer .chips{
+      display:flex;
+      flex-wrap:wrap;
+      gap:.35rem;
+    }
+
+    footer{
+      border-top:1px solid rgba(15,23,42,.08);
+      padding:18px 0 22px;
+      color:#9ca3af;
+      font-size:.75rem;
+    }
+    footer .row{
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      gap:1rem;
+      flex-wrap:wrap;
+    }
+  </style>
+</head>
+<body>
+  <!-- NAV -->
+  <div class="nav">
+    <div class="container row">
+      <a class="brand" href="../../index.html">
+        <img src="../../images/logo_transparente.png" alt="Guardianes del Pulque" class="brand-logo">
+        <span class="brand-text">Guardianes del Pulque</span>
+      </a>
+      <div class="links">
+        <a class="chip" href="../posts.html">Articulos</a>
+        <a class="chip" href="../../index.html#donar"><span class="emoji">💚</span> Donar</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- HERO -->
+  <header class="hero-article">
+    <div class="hero-inner">
+      <div class="eyebrow">${emoji} ${tag}</div>
+      <h1 class="title">${title}</h1>
+      <p class="subtitle">${excerpt}</p>
+      <div class="meta">
+        <span>Por Guardianes del Pulque</span>
+        <span>${dateStr}</span>
+      </div>
+    </div>
+    <div class="cover-wrap">
+      <img src="${slug}.png" alt="${title}" class="cover-img">
+    </div>
+  </header>
+
+  <!-- CONTENIDO -->
+  <main class="article">
+    ${body}
+
+    <div class="divider"></div>
+
+    <!-- CTA -->
+    <section class="cta-section">
+      <h2>Suscribete al boletin</h2>
+      <p>Recibe articulos sobre pulque, bioconstruccion y defensa del territorio en tu correo.</p>
+      <form class="cta-form" action="#suscribirse" method="post">
+        <input type="email" placeholder="tu@correo.com" required>
+        <button type="submit">Suscribirme</button>
+      </form>
+      <a class="chip" href="../../index.html#donar"><span class="emoji">💚</span> Donar a Guardianes del Pulque</a>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- PIE DEL ARTICULO -->
+    <div class="article-footer">
+      <div class="chips">
+        <span class="chip">${emoji} ${tag}</span>
+      </div>
+      <div>
+        <a href="../posts.html" class="chip">← Volver a articulos</a>
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <footer>
+    <div class="container row">
+      <div style="display:flex;align-items:center;gap:.4rem">
+        <img src="../../images/logo_transparente.png" alt="Guardianes del Pulque" style="height:20px;width:auto">
+        <span>Guardianes del Pulque</span>
+      </div>
+      <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+        <a class="chip" href="../../index.html#donar"><span class="emoji">💚</span> Donar</a>
+        <a class="chip" href="../posts.html">Mas articulos</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>`;
+}
+
+// ── Flujo principal ────────────────────────────────────────────────────────
+async function generateArticle() {
+  const topic = pick(TOPICS);
+  const profile = pick(TONE_PROFILES);
+  const [minSec, maxSec] = profile.sectionRange;
+  const sectionCount = randInt(minSec, maxSec);
+  const temperature = randFloat(...profile.temperatureRange);
+
+  console.log(`Tema:  ${topic}`);
+  console.log(`Tono:  ${profile.name} (${sectionCount} secciones, temp ${temperature.toFixed(2)})`);
+
+  // 1. Generar articulo con GPT
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: profile.systemPrompt },
+      {
+        role: "user",
+        content:
+          `Escribe un articulo original sobre: ${topic}.\n\n` +
+          "Responde SOLO con un JSON valido (sin markdown ni backticks) con esta estructura:\n" +
+          `{"title": "Titulo del articulo", "excerpt": "Resumen de 1 linea (max 120 chars)", "tag": "Etiqueta principal", "body": "<h2>...</h2><p>...</p>..."}\n\n` +
+          `El body debe ser HTML con h2, p, ul/li y ol/li. Usa exactamente ${sectionCount} secciones con h2. ` +
+          "No incluyas el titulo principal en el body. No uses etiquetas style ni script. " +
+          "Sin fuentes ni referencias.\n\n" +
+          `Para el tag, elige el mas apropiado entre: ${VALID_TAGS.join(", ")}. ` +
+          "Si ninguno encaja, puedes sugerir uno nuevo.\n\n" +
+          "Termina el articulo con un parrafo de cierre motivador.",
+      },
+    ],
+    temperature,
+  });
+
+  const raw = completion.choices[0].message.content.trim();
+  const article = JSON.parse(raw);
+
+  // 2. Validar tag
+  const tag = validateTag(article.tag);
+  const emoji = TAG_EMOJI[tag] || "📝";
+
+  // 3. Generar slug unico
+  const baseSlug = slugify(article.title);
+  const slug = uniqueSlug(baseSlug);
+
+  // 4. Generar imagen con DALL-E
+  console.log("Generando imagen DALL-E...");
+  const imageResponse = await openai.images.generate({
+    model: "dall-e-3",
+    prompt:
+      `Mural mexicano inspirado en Diego Rivera y Siqueiros sobre: "${article.title}". ` +
+      "Colores tierra, ocre, verde y rojo oxido. Sin texto ni letras.",
+    n: 1,
+    size: "1792x1024",
+  });
+
+  const imageUrl = imageResponse.data[0].url;
+  const imageBuffer = Buffer.from(
+    await fetch(imageUrl).then((r) => r.arrayBuffer())
+  );
+
+  // 5. Guardar imagen
+  const artDir = path.join(__dirname, "..", "articulos", slug);
+  fs.mkdirSync(artDir, { recursive: true });
+  fs.writeFileSync(path.join(artDir, `${slug}.png`), imageBuffer);
+
+  // 6. Generar y guardar HTML
+  const now = new Date();
+  const dateStr = fechaMx(now);
+  const html = buildHTML({
+    title: article.title,
+    excerpt: article.excerpt,
+    body: article.body,
+    tag,
+    emoji,
+    slug,
+    dateStr,
+  });
+  fs.writeFileSync(path.join(artDir, `${slug}.html`), html);
+
+  // 7. Actualizar posts.json
+  const postsPath = path.join(__dirname, "..", "posts.json");
+  const posts = JSON.parse(fs.readFileSync(postsPath, "utf-8"));
+  posts.unshift({
+    tag,
+    title: article.title,
+    excerpt: article.excerpt,
+    date: dateStr,
+    url: `articulos/${slug}/${slug}.html`,
+    cover: `articulos/${slug}/${slug}.png`,
+  });
+  fs.writeFileSync(postsPath, JSON.stringify(posts, null, 2) + "\n");
+
+  console.log(`\nCreado: articulos/${slug}/${slug}.html`);
+  console.log(`Cover:  articulos/${slug}/${slug}.png`);
+  console.log(`Tag:    ${emoji} ${tag}`);
+  console.log(`Titulo: ${article.title}`);
+  console.log(`Fecha:  ${dateStr}`);
+  console.log(`Tono:   ${profile.name}`);
+}
+
+generateArticle().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumen
- Agrega meta tags Open Graph y Twitter Cards + JSON-LD (Organization) a `index.html`
- Agrega meta tags Open Graph y Twitter Cards + JSON-LD (Article) a los 3 artículos existentes
- Actualiza el template en `generate-post.js` para que los artículos auto-generados semanalmente por el GitHub Action incluyan OG/Twitter/JSON-LD automáticamente
- Agrega constante `SITE_URL` y parámetro `isoDate` al flujo de generación

## Contexto
El sitio no tenía metadatos estructurados. Al compartir en redes sociales no se mostraba imagen ni descripción rica, y los buscadores no podían extraer datos estructurados. Con este PR, tanto las páginas existentes como las futuras publicaciones automáticas tendrán previews ricos al compartirse.

## Plan de pruebas
- [ ] Validar JSON-LD con https://validator.schema.org
- [ ] Compartir enlace en Twitter/Facebook y verificar preview rico
- [ ] Ejecutar `node scripts/generate-post.js` y confirmar que el HTML generado incluye los meta tags

🤖 Generado con [Claude Code](https://claude.com/claude-code)