### PR TITLE
feat: muralismo mexicano + sub-estilos variados para imágenes DALL-E

### DIFF
--- a/scripts/generate-post.js
+++ b/scripts/generate-post.js
@@ -60,6 +60,10 @@ const IMAGE_SUBSTYLES = [
     name: "encaustica",
     desc: "encáustica con cera caliente y pigmentos, superficie translúcida con vetas y burbujas",
   },
+  {
+    name: "pastel-costumbrista",
+    desc: "ilustración costumbrista en lápiz de color y pastel seco sobre papel granulado, trazos suaves visibles, textura arenosa cálida, tonos ocre-dorado y tierra, figuras con volumen sutil y expresiones amables, luz difusa dorada de atardecer",
+  },
 ];
 
 const TAG_PALETTES = {


### PR DESCRIPTION
## Summary

- Reemplaza los 3 estilos genéricos (mural, impresionista, acuarela) por **8 sub-estilos de muralismo mexicano** (óleo-empaste, fresco-cal, técnica-mixta, expresionismo-terroso, claroscuro-social, temple-antiguo, litografía-color, encáustica)
- Agrega **paletas de color por tag**: ámbar/dorado (Pulque), arcilla/terracota (Bioconstruccion), verde/agua (Naturaleza), rojo/obsidiana (Territorio)
- **Tracking de estilos usados** en `posts.json` (`imageStyle` field) para no repetir sub-estilo entre artículos
- Todos los prompts incluyen: "textura de óleo visible, pinceladas gruesas, NO ilustración digital, NO render 3D"

Closes #3

## Test plan

- [ ] Ejecutar `node scripts/generate-post.js` y verificar que el sub-estilo se loguea en consola
- [ ] Verificar que `posts.json` incluye el campo `imageStyle` en el nuevo artículo
- [ ] Generar 2+ artículos y confirmar que no repiten sub-estilo
- [ ] Revisar visualmente que las imágenes tienen estética de muralismo mexicano

🤖 Generated with [Claude Code](https://claude.com/claude-code)